### PR TITLE
Check if brew is installed before loading completion2

### DIFF
--- a/bashrc.d/05-bash-completion2.sh
+++ b/bashrc.d/05-bash-completion2.sh
@@ -1,1 +1,4 @@
-[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+if cmd=$(command -v brew);
+then
+    [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+fi


### PR DESCRIPTION
I was not checking if brew was installed on the system before making an
attempt to load the bash-completion2 scripts.

This was causing errors in non-macos system, and more in general for mac
with Homebrew not installed